### PR TITLE
Allow continuing past 500 errors.

### DIFF
--- a/layervault.lua
+++ b/layervault.lua
@@ -185,6 +185,9 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
       io.stdout:flush()
       tries = 0
       return wget.actions.EXIT
+    elseif tries >= 2 and status_code == 500 then
+      io.stdout:write("\nMoving on...\n")
+      io.stdout:flush()
     elseif tries >= 15 then
       io.stdout:write("\nI give up...\n")
       io.stdout:flush()


### PR DESCRIPTION
If a 500 error is repeated twice, ignore it and move on. 500 errors seem to persist over time, and always on the same items. Revisiting them would be ideal, but possibly not practical by the April 11 deadline.

Unfortunately, this doesn't log the work units that ran in to 500 errors, so any identification would have to be done on the server side. That doesn't appear to be set up as a possibility, so 500 errors will likely be ignored. If the 500 errors will be recoverable, then this is the wrong course of action. Otherwise, it will allow work units to actually finish, where those could have had data past the 500'ing files. It's not an ideal fix, but it might be the best we can do at the moment.
